### PR TITLE
Update the crate name, add more doc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "ngrok-api-rs"
+name = "ngrok-api"
 version = "0.1.0"
 dependencies = [
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ngrok-api-rs"
+name = "ngrok-api"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/create_edge.rs
+++ b/examples/create_edge.rs
@@ -1,7 +1,7 @@
 use futures::stream::StreamExt;
 
-use ngrok_api_rs::types::HTTPSEdge;
-use ngrok_api_rs::{Client, ClientConfig, Error};
+use ngrok_api::types::HTTPSEdge;
+use ngrok_api::{Client, ClientConfig, Error};
 
 #[tokio::main]
 async fn main() {
@@ -15,7 +15,7 @@ async fn main() {
     let resp = c
         .edges()
         .https()
-        .create(&ngrok_api_rs::types::HTTPSEdgeCreate {
+        .create(&ngrok_api::types::HTTPSEdgeCreate {
             description: "made from rust".into(),
             ..Default::default()
         })

--- a/examples/create_edge.rs
+++ b/examples/create_edge.rs
@@ -8,7 +8,7 @@ async fn main() {
     let token = std::env::var("NGROK_API_KEY").expect("Set NGROK_API_KEY env var");
 
     let c = Client::new(ClientConfig {
-        auth_token: token.to_owned(),
+        api_key: token.to_owned(),
         api_url: None,
     });
 

--- a/examples/reserved_domain.rs
+++ b/examples/reserved_domain.rs
@@ -10,7 +10,7 @@ async fn main() {
     let token = std::env::var("NGROK_API_KEY").expect("Set NGROK_API_KEY env var");
 
     let c = Client::new(ClientConfig {
-        auth_token: token.to_owned(),
+        api_key: token.to_owned(),
         api_url: None,
     });
 

--- a/examples/reserved_domain.rs
+++ b/examples/reserved_domain.rs
@@ -1,7 +1,7 @@
 use futures::stream::StreamExt;
 
-use ngrok_api_rs::types;
-use ngrok_api_rs::{Client, ClientConfig, Error};
+use ngrok_api::types;
+use ngrok_api::{Client, ClientConfig, Error};
 
 use rand::Rng;
 


### PR DESCRIPTION
The name should have been `ngrok-api`, not `ngrok-api-rs`.

I also used the wrong terminology for `api_key`, and was missing some docs.

Make appropriate updates for that.