### PR TITLE
Use `domain` instead of `name` in reserved domain example

### DIFF
--- a/examples/reserved_domain.rs
+++ b/examples/reserved_domain.rs
@@ -17,7 +17,7 @@ async fn main() {
     let rand: u64 = rand::thread_rng().gen();
     let resp = rd
         .create(&types::ReservedDomainCreate {
-            name: format!("rustexample{}", rand),
+            domain: format!("rustexample{}.ngrok.io", rand),
             ..Default::default()
         })
         .await


### PR DESCRIPTION
`name` has been deprecated in favor of `domain`