### PR TITLE
Update Cargo.toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok-api"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "ngrok API client library for Rust"


### PR DESCRIPTION
Turns out this has been a manual release process for the rust api client, including this step to bump the cargo.toml version