### PR TITLE
fix: switch reqwest to rustls-tls to fix native-tls build failure wit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 <!-- Code generated for API Clients. DO NOT EDIT. -->
+## 0.12.0
+* **BREAKING**: Upgraded `reqwest` from `0.11` to `0.12`. If you pass a custom `reqwest::Client` via the builder, you must upgrade your `reqwest` dependency to `0.12`.
+* Switched TLS backend from `native-tls` to `rustls-tls` to fix compilation failures with recent Rust nightly toolchains.
+
 ## 0.11.0
 * Add support for `resolves_to` on Reserved Domains.
 * Deprecate API filtering via `id` and `url` query parameters. Please migrate to the filtering syntax described in [API Filtering](https://ngrok.com/docs/api/api-filtering).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok-api"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 description = "ngrok API client library for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ngrok/ngrok-api-rs"
 
 [dependencies]
 futures = "0.3.21"
-reqwest = { version = "0.11.9", features = ["json"] }
+reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version ="1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"


### PR DESCRIPTION
### Why

The `native-tls 0.2.17` crate fails to compile with recent Rust nightly toolchains (e.g. `2025-08-15`). The nightly compiler added a `Protocol::Tlsv13` variant that `native-tls 0.2.17` doesn't handle in its exhaustive match, causing a build failure:
error[E0004]: non-exhaustive patterns: Some(Protocol::Tlsv13) not covered


Since the flake uses an unpinned `fenix.complete` nightly toolchain, the same commit can pass or fail depending on when CI runs.

### How

- Bumped `reqwest` from `0.11.9` to `0.12.24`
- Switched from the default `native-tls` backend to `rustls-tls`, which is a pure-Rust TLS implementation and avoids the `native-tls` dependency entirely
- Disabled default features to ensure `native-tls` is not pulled in transitively

### Validation

- `cargo check` compiles successfully with the current nightly toolchain

The semver checks job will fail — it runs cargo-semver-checks which builds the previous published version (ngrok-api v0.11.0 from crates.io) to compare APIs. That old version still depends on native-tls 0.2.17 via reqwest 0.11.9, and it fails to compile with the current nightly.